### PR TITLE
Avoid refreshing all data when only a field changes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -58,7 +58,7 @@ build_flags =
 	-DFONT_TO_USE=1 # 1=Standard 2=Custom 3=French
 	-DHIDE_PASSWORD # Hide password input (else show it)
 	#-DAUTO_BRIGHTNESS
-	-DLIGHTWS # Only possible for version > 16088, decrease WS requests.
+	#-DLIGHTWS # Only possible for version > 16088, decrease WS requests.
 	-DPUSHOTA # To enable PUSH OTA (Don't enable both OTA)
 	#-DPULLOTA # To enable PULL OTA (Don't enable both OTA)
 	#-DCORE_DEBUG_LEVEL=5 # To enable debug on serial for librairies and core

--- a/src/conf/global_config.h
+++ b/src/conf/global_config.h
@@ -7,7 +7,7 @@
 #define CONFIG_VERSION 7
 
 // USED for OTA
-#define APPLICATION_VERSION "26.6.16-1"
+#define APPLICATION_VERSION "26.6.19-1"
 
 #if PAGES < 1
     #error PAGES should be at least 1

--- a/src/core/data_setup.cpp
+++ b/src/core/data_setup.cpp
@@ -13,7 +13,7 @@ Device myDevices[TOTAL_ICONX*TOTAL_ICONY];
 char TmpBuffer[255]; // To prevent multiple re-alloc
 static int tab[24]; // Tab for graph
 
-void RefreshWidgetsPanel(void);
+extern void RefreshWidgetsPanel(bool);
 
 static bool SetNewString(char **dst, const char *src)
 {
@@ -247,7 +247,7 @@ void Update_device_data(JsonObject RJson2)
             }
             else
             {
-                RefreshWidgetsPanel();
+                RefreshWidgetsPanel(true);
             }
         }
     }

--- a/src/core/data_setup.cpp
+++ b/src/core/data_setup.cpp
@@ -472,7 +472,7 @@ bool InitDeviceRequest(Device *dd, const char* c, bool isarray)
 
         if (!SetNewString(&d->name, i["Name"])) return false;
 
-        Serial.printf("Initialize Domoticz devices id: %d, name %s\n", d->idx, d->name);
+        //Serial.printf("Initialize Domoticz devices id: %d, name %s\n", d->idx, d->name);
 
         const char* JSondata = NULL;
         const char* type = NULL;

--- a/src/core/helper.cpp
+++ b/src/core/helper.cpp
@@ -20,13 +20,13 @@ void loadInfo(char* textChar, size_t textSize) {
     IPAddress localIp = WiFi.localIP();
 
     lv_snprintf(textChar, textSize,
-    "HEAP Memory Usable (Kb) %d, Max %d, Total %d\n", ESP.getMaxAllocHeap()/1024, ESP.getFreeHeap()/1024, ESP.getHeapSize()/1024);
+    "HEAP memory usable %d kB, max %d kB, total %d kB\n", ESP.getMaxAllocHeap()/1024, ESP.getFreeHeap()/1024, ESP.getHeapSize()/1024);
     #ifdef BOARD_HAS_PSRAM
     lv_snprintf(textChar + strlen(textChar), textSize - strlen(textChar),
-        "PSRAM Memory Free (Kb) %d, Total %d\n", ESP.getFreePsram()/1024, ESP.getPsramSize()/1024);
+        "PSRAM memory free %d kB, total %d kB\n", ESP.getFreePsram()/1024, ESP.getPsramSize()/1024);
     #endif
     lv_snprintf(textChar + strlen(textChar), textSize - strlen(textChar),
-    "LV Heap %d kB used (%d %%) %d%% frag.\n", used_size / 1024, mon.used_pct, mon.frag_pct);
+    "LV Heap %d kB used (%d %%), %d%% frag, largest %d kB, max %d kB, total %d kB\n", used_size / 1024, mon.used_pct, mon.frag_pct, mon.free_biggest_size / 1024, mon.max_used / 1024, mon.total_size / 1024);
     lv_snprintf(textChar + strlen(textChar), textSize - strlen(textChar),
     "Application Version : %s\n", APPLICATION_VERSION);
     lv_snprintf(textChar + strlen(textChar), textSize - strlen(textChar),

--- a/src/core/ip_engine.cpp
+++ b/src/core/ip_engine.cpp
@@ -181,7 +181,7 @@ static void webSocketEvent(WStype_t type, uint8_t * payload, size_t length)
             connect_ok = true;
 
 			// send message to server when Connected
-			WSclient.sendTXT("Connected");
+			//WSclient.sendTXT("Connected");
 
 			break;
 		case WStype_TEXT:

--- a/src/core/ip_engine.cpp
+++ b/src/core/ip_engine.cpp
@@ -8,8 +8,6 @@ static WebSocketsClient WSclient;
 static bool connect_ok = false;
 unsigned long total_data_lengh;
 
-extern char TmpBuffer[];
-
 void Update_device_data(JsonObject RJson2);
 void Update_scene_data(void);
 
@@ -45,16 +43,17 @@ bool HTTPGETRequestWithReturn(const char * url2, JsonDocument *doc, bool NeedFil
 {
 
     HTTPClient client;
-    lv_snprintf(TmpBuffer, 150, "http://%s:%d%s",global_config.ServerHost, global_config.ServerPort, url2);
+    int httpCode;
+    static char tmpBuffer[180];    // As routine is asynchronous, use only local data
+
+    lv_snprintf(tmpBuffer, sizeof(tmpBuffer), "http://%s:%d%s",global_config.ServerHost, global_config.ServerPort, url2);
     //String url = "http://" + String(global_config.ServerHost) + ":" + String(global_config.ServerPort) + url2;
 
-    int httpCode;
-
     try {
-        Serial.println(TmpBuffer);
+        Serial.println(tmpBuffer);
         client.useHTTP10(true); // Unfortunately, by using the underlying Stream, we bypass the code that handles chunked transfer encoding, so we must switch to HTTP version 1.0.
         client.setTimeout(1000);
-        client.begin(TmpBuffer);
+        client.begin(tmpBuffer);
         httpCode = client.GET();
         if (httpCode != 200)
         {

--- a/src/core/screen_driver.cpp
+++ b/src/core/screen_driver.cpp
@@ -4,6 +4,8 @@
 #include "../ui/main_ui.h"
 #include "lvgl.h"
 #include "../ui/navigation.h"
+#include "ip_engine.h"
+
 #ifndef LV_VDB_SIZE
 #if defined(ARDUINO_ARCH_ESP8266)
 #  define LV_VDB_SIZE    (8 * 1024U)   // Minimum 8 Kb
@@ -490,7 +492,7 @@ void set_screen_timer_period()
 
 void home_timer_sleep(lv_timer_t *timer)
 {
-    navigation_screen(HOMEPAGE_PANEL);
+    if (WS_Running()) navigation_screen(HOMEPAGE_PANEL);
 }
 
 void home_timer_setup()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,7 +162,7 @@ analogSetAttenuation(ADC_0db); // 0dB(1.0x) 0~800mV
 #endif
 
     //make_sound(500,500);
-    dumpConfig();
+    //dumpConfig();
 
     Serial.println(F("Application ready"));
 

--- a/src/ui/navigation.cpp
+++ b/src/ui/navigation.cpp
@@ -31,11 +31,11 @@ void ReturnPreviouspage(void)
     navigation_screen(master_panel);
 }
 
-void RefreshWidgetsPanel(void)
+void RefreshWidgetsPanel(bool dontLoadData)
 {
     if (actived_panel >= HOMEPAGE_PANEL && actived_panel <= LAST_PAGE_PANEL)
     {                           
-        navigation_screen(actived_panel);
+        navigation_screen(actived_panel, dontLoadData);
     }
 }
 
@@ -57,7 +57,7 @@ void RefreshScenePanel(void)
 }
 #endif
 
-void navigation_screen(unsigned char active_panel)
+void navigation_screen(unsigned char active_panel, bool dontLoadData)
 {
     actived_panel = active_panel;
 
@@ -82,7 +82,7 @@ void navigation_screen(unsigned char active_panel)
             break;
         case HOMEPAGE_PANEL ... (LAST_PAGE_PANEL): // Widget pages
             master_panel = active_panel;
-            widget_panel_init(panel);
+            widget_panel_init(panel, dontLoadData);
             break;
 #ifndef NO_GROUP_PAGE
         case GROUP_PANEL: //Group/Scene panel

--- a/src/ui/navigation.h
+++ b/src/ui/navigation.h
@@ -1,11 +1,11 @@
 
-void navigation_screen(unsigned char active_panel);
+void navigation_screen(unsigned char active_panel, bool dontLoadData = false);
 void ReturnPreviouspage(void);
 void nav_style_setup();
 int GetActiveWidgetPage(void);
 int GetActivePanel(void);
 void SetActivePanel(int);
-void RefreshWidgetsPanel(void);
+void RefreshWidgetsPanel(bool dontLoadData = false);
 void RefreshScenePanel(void);
 void RefreshDevicePanel(void);
 

--- a/src/ui/panels/panel.h
+++ b/src/ui/panels/panel.h
@@ -5,7 +5,7 @@
 #define SIZEOF(arr) (sizeof(arr) / sizeof(*arr))
 
 void settings_panel_init(lv_obj_t* panel);
-void widget_panel_init(lv_obj_t* panel);
+void widget_panel_init(lv_obj_t* panel, bool init_data_widget = true);
 void info_panel_init(lv_obj_t* panel);
 void group_panel_init(lv_obj_t* panel);
 void device_panel_init(lv_obj_t* panel);

--- a/src/ui/panels/widgets_panel.cpp
+++ b/src/ui/panels/widgets_panel.cpp
@@ -251,46 +251,16 @@ static void Widget_text(lv_obj_t* panel, char* desc, char* value, int x, int y, 
     lv_obj_t * label = lv_label_create(Button_icon);
     lv_obj_set_style_text_font(label, &big_font_bold, 0);
     lv_obj_set_style_text_color(label, color, 0);
-    lv_label_set_long_mode(label, LV_LABEL_LONG_DOT);             /*Break the long lines*/
+    lv_label_set_long_mode(label, LV_LABEL_LONG_DOT);             /*Add dot at end of long lines*/
     //lv_label_set_text(label, value);
 
-    int _height = 0;
+    int value_height = 0;
     int desc_height = 0;
     lv_point_t textSize;
-#if DEVICE_SIZE == 1
-    desc_height = 14;
-#else
-    desc_height = 16;
-#endif
 
     //No description for short text (eg time)
-    if (strlen(d->data) < 6) desc_height = 0;
-
-    _height = Size_h - desc_height; // Total size - 1 line small police for device name (Yeah i know, not good if the device name need 2 lines .....)
-
-    lv_obj_set_height(label, _height);
-    lv_obj_set_width(label, Size_w);
-
-    // Try to reduce font size to display as much as text as possible
-    for (uint8_t i = 0; i < sizeof(fonts) / sizeof(lv_font_t); i++) {
-        // Use lv_obj_get_width(label) don't work on my side, forced to use Size_w
-        lv_txt_get_size(&textSize, value, &fonts[i], 0, 0, Size_w, LV_TEXT_FLAG_NONE);
-        lv_obj_set_style_text_font(label, &fonts[i], 0);
-        if (textSize.y <= _height) {
-            break;
-        }
-    }
-
-    lv_obj_set_height(label, textSize.y);
-
-    //lv_obj_align_to(label, Button_icon,  LV_ALIGN_TOP_MID, 0, -20);
-    lv_obj_align_to(label, Button_icon,  LV_ALIGN_CENTER, 0, -(desc_height/2)); // Horizontal align for widget
-    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0); // Horizontal align for text inside the widget
-
-    lv_label_set_text(label, value);
-
-    if (desc_height)
-    {
+    //if (strlen(d->data) >= 6)
+    //{
         /*Create description*/
         lv_obj_t * label2 = lv_label_create(Button_icon);
         lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
@@ -299,7 +269,35 @@ static void Widget_text(lv_obj_t* panel, char* desc, char* value, int x, int y, 
         lv_label_set_text(label2, desc);
         lv_obj_set_width(label2, Size_w);
         lv_obj_align_to(label2, Button_icon,  LV_ALIGN_BOTTOM_MID, 0, 10);
+        lv_obj_update_layout(label2);   // Recompute all label2 parameters
+        value_height = lv_obj_get_y(label2) - 1; // Space before description
+        desc_height = h - value_height;  // Height of descriptor
+        ////lv_obj_set_style_outline_width(label2, 1, 0);
+        ////lv_obj_set_style_outline_color(label2, LV_COLOR_MAKE(0xFF, 0x00, 0x00), 0); ////
+    //} else {
+    //    value_height = Size_h;
+    //}
+
+    lv_obj_set_size(label, w, value_height);
+
+    // Try to reduce font size to display as much as text as possible
+    for (uint8_t i = 0; i < sizeof(fonts) / sizeof(lv_font_t); i++) {
+        lv_txt_get_size(&textSize, value, &fonts[i], 0, 0, w, LV_TEXT_FLAG_NONE); // Get text size
+        lv_obj_set_style_text_font(label, &fonts[i], 0);    // Set current font
+        if (textSize.y <= value_height) {    // Does text fit in label?
+            break;  // Don't try other fonts
+        }
     }
+
+    if (textSize.y > value_height) { // Dont oversize label if too long
+        textSize.y = value_height;
+    }
+    lv_obj_set_height(label, textSize.y);
+    lv_obj_align_to(label, Button_icon,  LV_ALIGN_TOP_MID, 0, -10 + (value_height - textSize.y)/2); // Horizontal align for widget
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0); // Horizontal align for text inside the widget
+    lv_label_set_text(label, value);
+    ////lv_obj_set_style_outline_width(label, 1, 0);
+    ////lv_obj_set_style_outline_color(label, LV_COLOR_MAKE(0x00, 0xFF, 0x00), 0);
 }
 
 static void Widget_button_group(lv_obj_t* panel, char* desc, int x, int y, int w, int h, lv_color_t color, int idx, const lv_img_dsc_t* icon, bool state, bool group)

--- a/src/ui/panels/widgets_panel.cpp
+++ b/src/ui/panels/widgets_panel.cpp
@@ -347,13 +347,13 @@ static void Widget_button_group(lv_obj_t* panel, char* desc, int x, int y, int w
 
 }
 
-void widget_panel_init(lv_obj_t* panel)
+void widget_panel_init(lv_obj_t* panel, bool dont_load_data)
 {
     short x,y;
     short cx,cy;
     short i = 0;
 
-    Init_data_widget_page();
+     if (!dont_load_data) Init_data_widget_page();
 
     for (y=0; y<TOTAL_ICONY; y=y+1)
     {

--- a/src/ui/panels/widgets_panel.cpp
+++ b/src/ui/panels/widgets_panel.cpp
@@ -260,7 +260,7 @@ static void Widget_text(lv_obj_t* panel, char* desc, char* value, int x, int y, 
 #if DEVICE_SIZE == 1
     desc_height = 14;
 #else
-    desc_height = 16
+    desc_height = 16;
 #endif
 
     //No description for short text (eg time)


### PR DESCRIPTION
Avoid refreshing all data when only a field changes:
- before this change, when an update was received, concerned device data was updated, but instead of just refreshing page, all devices of current pages where requested again from Domoticz, making unitary update useless.

Reduce log:
- remove configuration dump at startup
- remove list of loaded device when loading each page
- they have just been commented, so easily added back for debug, if needed

Use local temporary buffer:
- buffer used to send websocket command was share with other code, making amazing side effect potentially happening.

Don't revert to home page until websocket is connected:
- avoid going back to home page before wifi and websocket connected

Don't send unneeded message at websocket connection:
- a useless "Connected" was sent to Domoticz just after connection
- this is probably a cut&paste from an example

Disable LIGHTWS as it don't works:
- as of now, sending JSON request to websocket disconnects it (for an unknown reason)
- websocket is automatically reconnected after 5 seconds, giving by default all changes
- however, all changes between request and reconnection are lost
- disabling LIGHTWS keeps default behavior of getting all changes, and don't miss any changes, including those between HTTP request and websocket request.

Fix a typo in Widget_text:
- add a missing ; at end of line, when compiling with DEVICE_SIZE=3

Add details to tools panel and debug:
- add some memory fields
- unify size in kB

Fix Widget_text:
- make widget_text routine auto-adaptative (text will auto size over space left by description, better font will be chosen)
- don't depend anymore about DEVICE_SIZE