### PR TITLE
Change websocket buffer size for large screens

### DIFF
--- a/changeWsBufferSize.py
+++ b/changeWsBufferSize.py
@@ -1,0 +1,77 @@
+"""
+
+This script changes WebSockets buffer size for ESP8266 and ESP32
+    from 15K to 25K in order to allow receiving large buffers from Domoticz
+
+It's run by (pre) extra_script command in platformio.ini
+
+"""
+
+import os
+import pathlib
+import sys
+import inspect
+Import("env")
+
+def trace_log(message):
+    """
+        Write a message on screen
+    """
+    print(F"{thisScriptFileName}: {message}")
+
+# Dump global construction environment (for debug purpose)
+# print(env.Dump())
+
+# Extract full/path/name from this script file
+thisScriptFullFileName = inspect.getouterframes(inspect.currentframe())[0].filename
+thisScriptPath = pathlib.Path(thisScriptFullFileName).parent.resolve()
+thisScriptFileName = pathlib.Path(thisScriptFullFileName).name
+
+# Name of LIB_DEPS folder
+PROJECT_LIBDEPS_DIR = env['PROJECT_LIBDEPS_DIR']
+
+# Name of .PIO folder
+PIOENV = env['PIOENV']
+
+# Elements specific to this script (path/file name, line to change)
+LIBRARY_NAME = 'WebSockets'
+LIBRARY_FOLDER = 'src'
+FILE_TO_CHANGE = 'WebSockets.h'
+CHANGE_FROM = "#if defined(ESP8266) || defined(ESP32)\r\n" \
+            +  "\r\n" \
+            +  "#define WEBSOCKETS_MAX_DATA_SIZE (15 * 1024)\r\n"
+CHANGE_TO   = "#if defined(ESP8266) || defined(ESP32)\r\n" \
+            +  "\r\n" \
+            +  "#define WEBSOCKETS_MAX_DATA_SIZE (25 * 1024)\r\n"
+
+# Compose the full file name
+fullFileName = os.path.join(PROJECT_LIBDEPS_DIR, PIOENV, \
+    LIBRARY_NAME, LIBRARY_FOLDER, FILE_TO_CHANGE)
+
+# Make path relative to reduce length
+relativeFileName = os.path.relpath(fullFileName)
+
+# Check for file existence
+if os.path.isfile(relativeFileName):
+    # Read full file content in binary and convert it to text
+    with open(relativeFileName, 'rb') as inputStream:
+        binaryContent = inputStream.read()
+        textContent = binaryContent.decode(encoding='utf-8')
+    # Check for original sequence
+    if textContent.find(CHANGE_FROM) >= 0:
+        # Replace sequence, convert it to bianry and overwrite file
+        textContent = textContent.replace(CHANGE_FROM, CHANGE_TO)
+        binaryContent = textContent.encode('utf-8')
+        with open(relativeFileName, 'wb') as outputStream:
+            outputStream.write(binaryContent)
+        trace_log(F'File {relativeFileName} changed')
+    # Check for target sequence
+    elif textContent.find(CHANGE_TO) >= 0:
+        trace_log(F'File {relativeFileName} already changed')
+    # Don't find both sequences
+    else:
+        trace_log(F'*** Can\'t find change sequences in {relativeFileName} ***')
+        sys.exit(1)
+else:
+    trace_log(F'*** File {relativeFileName} *NOT* found ***')
+    sys.exit(1)

--- a/platformio.ini
+++ b/platformio.ini
@@ -59,7 +59,7 @@ build_flags =
 	-DHIDE_PASSWORD # Hide password input (else show it)
 	#-DAUTO_BRIGHTNESS
 	-DDIM_OFF_ICONS # Change Off/Closed devices icons to grey
-	#-DLIGHTWS # Only possible for version > 16088, decrease WS requests.
+	-DLIGHTWS # Only possible for version > 16088, decrease WS requests.
 	-DPUSHOTA # To enable PUSH OTA (Don't enable both OTA)
 	#-DPULLOTA # To enable PULL OTA (Don't enable both OTA)
 	#-DCORE_DEBUG_LEVEL=5 # To enable debug on serial for librairies and core
@@ -378,6 +378,8 @@ build_flags =
 	-DTOTAL_ICONX=4 # How many icon widht
 	-DTOTAL_ICONY=4 # How many icon Heigh
 	-DDEVICE_SIZE=3 # Device display size
+extra_scripts =
+    pre:changeWsBufferSize.py
 
 lib_deps =
     ;Arduino_RPi_DPI_RGBPanel_mod
@@ -412,6 +414,8 @@ build_flags =
 	-DTOTAL_ICONX=4 # How many icon widht
 	-DTOTAL_ICONY=4 # How many icon Heigh
 	-DDEVICE_SIZE=3 # Device display size
+extra_scripts =
+    pre:changeWsBufferSize.py
 
 ;flash 16M
 board_upload.flash_size = 16MB
@@ -437,6 +441,8 @@ build_flags =
 	-DTOTAL_ICONX=4 # How many icon widht
 	-DTOTAL_ICONY=4 # How many icon Heigh
 	-DDEVICE_SIZE=3 # Device display size
+extra_scripts =
+    pre:changeWsBufferSize.py
 
 lib_deps =
 	lovyan03/LovyanGFX@^1.1.8
@@ -463,6 +469,8 @@ build_flags =
 	-DTOTAL_ICONX=4 # How many icon widht
 	-DTOTAL_ICONY=4 # How many icon Heigh
 	-DDEVICE_SIZE=3 # Device display size
+extra_scripts =
+    pre:changeWsBufferSize.py
 
 lib_deps =
     ;Arduino_RPi_DPI_RGBPanel_mod
@@ -516,6 +524,8 @@ build_flags =
 	-DTOTAL_ICONX=4 # How many icon widht
 	-DTOTAL_ICONY=4 # How many icon Heigh
 	-DDEVICE_SIZE=3 # Device display size
+extra_scripts =
+    pre:changeWsBufferSize.py
 
 [env:esp32-S3TOUCHLCD7]
 board_build.mcu = esp32s3

--- a/src/conf/global_config.h
+++ b/src/conf/global_config.h
@@ -7,7 +7,7 @@
 #define CONFIG_VERSION 7
 
 // USED for OTA
-#define APPLICATION_VERSION "26.6.29-1"
+#define APPLICATION_VERSION "26.6.30-1"
 
 #if PAGES < 1
     #error PAGES should be at least 1


### PR DESCRIPTION
By default, websocket buffer size is set to 15K. This fit for around 9 or 10 devices. Large screens (16 devices) need larger buffers (between 22 to 24K). This change modify websocket buffer size to 25K.

Change is implemented using "pre" extra script in platformio.ini to run changeWsBufferSize.py before project compilation.

This script reads WebSockets.h file, in WebSockets library, and replaces WEBSOCKETS_MAX_DATA_SIZE definition from 15 * 1024 to 25 * 1024 for ESP8266 and ESP32, if not already done.

This allows websocket to properly run on large screen (instead of disconnecting websocket).