### PR TITLE
Ignore touch actions when reactivating screen

### DIFF
--- a/src/conf/global_config.h
+++ b/src/conf/global_config.h
@@ -7,7 +7,7 @@
 #define CONFIG_VERSION 7
 
 // USED for OTA
-#define APPLICATION_VERSION "26.6.30-1"
+#define APPLICATION_VERSION "26.7.23-1"
 
 #if PAGES < 1
     #error PAGES should be at least 1

--- a/src/core/screen_driver.cpp
+++ b/src/core/screen_driver.cpp
@@ -430,12 +430,17 @@ void set_screen_brightness()
 void screen_timer_wake()
 {
     lv_timer_reset(screenSleepTimer);
+    screenRestartTime = millis();
     isScreenInSleep = false;
     set_screen_brightness();
 
     // Reset cpu freq
     setCpuFrequencyMhz(CPU_FREQ_HIGH);
     Serial.printf("CPU Speed: %d MHz\n", ESP.getCpuFreqMHz());
+}
+
+bool screen_ignore_action(void) {
+    return ((millis() - screenRestartTime) < 500);   // Ignore actions for 0.5 sec after restarting (reactivating) screen
 }
 
 void screen_timer_sleep(lv_timer_t *timer)

--- a/src/core/screen_driver.cpp
+++ b/src/core/screen_driver.cpp
@@ -430,17 +430,12 @@ void set_screen_brightness()
 void screen_timer_wake()
 {
     lv_timer_reset(screenSleepTimer);
-    screenRestartTime = millis();
     isScreenInSleep = false;
     set_screen_brightness();
 
     // Reset cpu freq
     setCpuFrequencyMhz(CPU_FREQ_HIGH);
     Serial.printf("CPU Speed: %d MHz\n", ESP.getCpuFreqMHz());
-}
-
-bool screen_ignore_action(void) {
-    return ((millis() - screenRestartTime) < 500);   // Ignore actions for 0.5 sec after restarting (reactivating) screen
 }
 
 void screen_timer_sleep(lv_timer_t *timer)
@@ -560,19 +555,23 @@ void screen_lv_flush(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *col
 void screen_lv_touchRead(lv_indev_drv_t *indev_driver, lv_indev_data_t *data)
 {
     TS_Point p;
+    static bool ignoreNextTouch;
 
     if (touchscreen.tirqTouched() && touchscreen.touched())
     {
         lv_timer_reset(screenSleepTimer);
         lv_timer_reset(homeSleepTimer);
-        // dont pass first touch after power on
         if (isScreenInSleep)
         {
             screen_timer_wake();
+            ignoreNextTouch = true;
+        }
 
-            while (touchscreen.touched())
-                ;
-            return;
+        // dont pass first touch after power on
+        if (ignoreNextTouch)
+        {
+             data->state = LV_INDEV_STATE_REL;
+             return;
         }
 
         p = touchscreen.getPoint();
@@ -586,9 +585,9 @@ void screen_lv_touchRead(lv_indev_drv_t *indev_driver, lv_indev_data_t *data)
     else
     {
         data->state = LV_INDEV_STATE_REL;
+        ignoreNextTouch = false;
     }
 }
-
 
 void set_color_scheme(){
     lv_disp_t *dispp = lv_disp_get_default();

--- a/src/ui/navigation.h
+++ b/src/ui/navigation.h
@@ -8,10 +8,13 @@ void SetActivePanel(int);
 void RefreshWidgetsPanel(bool dontLoadData = false);
 void RefreshScenePanel(void);
 void RefreshDevicePanel(void);
+bool screen_ignore_action(void);
 
 int checkAdminRights(const int, const int);
 bool isPageProtected(int page);
 void password_keyboard_display(lv_obj_t* panel);
+
+static unsigned long screenRestartTime = 0;
 
 #define DATA_REMOTE_STATE 1
 #define DATA_REMOTE_DATA 2

--- a/src/ui/navigation.h
+++ b/src/ui/navigation.h
@@ -8,13 +8,10 @@ void SetActivePanel(int);
 void RefreshWidgetsPanel(bool dontLoadData = false);
 void RefreshScenePanel(void);
 void RefreshDevicePanel(void);
-bool screen_ignore_action(void);
 
 int checkAdminRights(const int, const int);
 bool isPageProtected(int page);
 void password_keyboard_display(lv_obj_t* panel);
-
-static unsigned long screenRestartTime = 0;
 
 #define DATA_REMOTE_STATE 1
 #define DATA_REMOTE_DATA 2

--- a/src/ui/panels/widgets_panel.cpp
+++ b/src/ui/panels/widgets_panel.cpp
@@ -29,6 +29,7 @@ static void go_page_cb(int pagrPtr);
 
 static void btn_event_cb_group(lv_event_t * e)
 {
+    if (screen_ignore_action()) return;   // Ignore action just after screen reactivation
     int idx = (int)lv_event_get_user_data(e);
     lv_obj_t * btn = lv_event_get_target(e);
     lv_event_code_t code = lv_event_get_code(e);
@@ -58,6 +59,7 @@ static void btn_event_cb_group(lv_event_t * e)
 
 static void btn_event_cb(lv_event_t * e)
 {
+    if (screen_ignore_action()) return;   // Ignore action just after screen reactivation
     //lv_event_code_t code = lv_event_get_code(e);
     //lv_obj_t * btn = lv_event_get_target(e);
     //int *d = (int*)lv_event_get_param(e);
@@ -87,6 +89,7 @@ static void btn_event_cb(lv_event_t * e)
 static void Widget_button(lv_obj_t* panel, char* desc, int x, int y, int w, int h, lv_color_t color, Device *d, const lv_img_dsc_t* icon)
 {
 
+    if (screen_ignore_action()) return;   // Ignore action just after screen reactivation
     /*Create a container with ROW flex direction*/
     lv_obj_t * Button_icon = lv_obj_create(panel);
     lv_obj_set_size(Button_icon, w, h);

--- a/src/ui/panels/widgets_panel.cpp
+++ b/src/ui/panels/widgets_panel.cpp
@@ -29,7 +29,6 @@ static void go_page_cb(int pagrPtr);
 
 static void btn_event_cb_group(lv_event_t * e)
 {
-    if (screen_ignore_action()) return;   // Ignore action just after screen reactivation
     int idx = (int)lv_event_get_user_data(e);
     lv_obj_t * btn = lv_event_get_target(e);
     lv_event_code_t code = lv_event_get_code(e);
@@ -59,7 +58,6 @@ static void btn_event_cb_group(lv_event_t * e)
 
 static void btn_event_cb(lv_event_t * e)
 {
-    if (screen_ignore_action()) return;   // Ignore action just after screen reactivation
     //lv_event_code_t code = lv_event_get_code(e);
     //lv_obj_t * btn = lv_event_get_target(e);
     //int *d = (int*)lv_event_get_param(e);
@@ -88,8 +86,6 @@ static void btn_event_cb(lv_event_t * e)
 
 static void Widget_button(lv_obj_t* panel, char* desc, int x, int y, int w, int h, lv_color_t color, Device *d, const lv_img_dsc_t* icon)
 {
-
-    if (screen_ignore_action()) return;   // Ignore action just after screen reactivation
     /*Create a container with ROW flex direction*/
     lv_obj_t * Button_icon = lv_obj_create(panel);
     lv_obj_set_size(Button_icon, w, h);

--- a/src/ui/wifi_setup.cpp
+++ b/src/ui/wifi_setup.cpp
@@ -189,6 +189,7 @@ void wifi_init()
     Serial.print(F("Wifi connecting to SSID: "));
     Serial.println(global_config.wifiSSID);
     WiFi.begin(global_config.wifiSSID, global_config.wifiPassword);
+    WiFi.setAutoReconnect(true);    // Force WiFi reconnection
     unsigned long startAttempt = millis();
 
     while (WiFi.status() != WL_CONNECTED)
@@ -226,5 +227,6 @@ void wifi_ok(){
 void wifi_stop(void)
 {
     WiFi.disconnect();
+    WiFi.setAutoReconnect(false);
     //wdt_reset();
 }


### PR DESCRIPTION
Before this change, when clicking on screen to reactivate it, touch action was activated (while screen was off), on unexpected change was done. We now wait for 0,5 sec before takins back actions on screen.

Also force WiFi reconnection (when WiFi is lost). Previously, we where obliged to reboot module to get WiFi back.