### PR TITLE
Reconnect to Domoticz and refresh devices when WiFi resumes

### DIFF
--- a/src/conf/global_config.h
+++ b/src/conf/global_config.h
@@ -7,7 +7,7 @@
 #define CONFIG_VERSION 7
 
 // USED for OTA
-#define APPLICATION_VERSION "26.7.23-1"
+#define APPLICATION_VERSION "26.7.30-1"
 
 #if PAGES < 1
     #error PAGES should be at least 1

--- a/src/ui/wifi_setup.cpp
+++ b/src/ui/wifi_setup.cpp
@@ -2,6 +2,7 @@
 #include "WiFi.h"
 #include "wifi_setup.h"
 #include "../conf/global_config.h"
+#include "navigation.h"
 
 void wifi_init_inner();
 
@@ -146,6 +147,12 @@ const char* errs[] = {
 const int print_freq = 1000;
 int print_timer = 0;
 
+// Called when WiFi is connected and IP set
+//  Force widget refresh to get last version of devices value
+void WiFiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
+    RefreshWidgetsPanel();  // Refresh widget if currently displayed
+}
+
 void wifi_init()
 {
 
@@ -188,6 +195,7 @@ void wifi_init()
 
     Serial.print(F("Wifi connecting to SSID: "));
     Serial.println(global_config.wifiSSID);
+    WiFi.onEvent(WiFiGotIP, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
     WiFi.begin(global_config.wifiSSID, global_config.wifiPassword);
     WiFi.setAutoReconnect(true);    // Force WiFi reconnection
     unsigned long startAttempt = millis();
@@ -216,17 +224,3 @@ void wifi_init()
     Serial.println(F("Wifi connected"));
 }
 
-void wifi_ok(){
-    if (WiFi.status() != WL_CONNECTED)
-    {
-        Serial.println(F("Wifi disconnection, restart"));
-        ESP.restart();
-    }
-}
-
-void wifi_stop(void)
-{
-    WiFi.disconnect();
-    WiFi.setAutoReconnect(false);
-    //wdt_reset();
-}

--- a/src/ui/wifi_setup.h
+++ b/src/ui/wifi_setup.h
@@ -1,3 +1,1 @@
 void wifi_init(void);
-void wifi_ok(void);
-void wifi_stop(void);


### PR DESCRIPTION
As of now, nothing specific is done when WiFi reconnects.

Devices updates during this period are lost. In addition, websocket connections are lost, meaning that no update will be received until changing page.

To avoid this, if current page is a widget one, page is forced to refresh (and reconnect) as soon as WiFi  is reconnected (more specifically IP received).